### PR TITLE
Feature/archive raws

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ version = "0.0.2"
 description = ""
 authors = ["apostoli <79337131+apostolos-geyer@users.noreply.github.com>"]
 readme = "README.md"
-packages = [
-    { include = "raipy_elt", from = "src" },
-]
+packages = [{ include = "raipy_elt", from = "src" }]
 
 [tool.poetry.scripts]
 raipy-elt = "raipy_elt.__main__:main"
@@ -15,7 +13,7 @@ raw2bronze = "raipy_elt.__main__:raw_to_bronze"
 [tool.poetry.dependencies]
 python = "^3.11"
 attrs = "^23.2.0"
-pandas = {extras = ["performance"], version = "^2.2.2"}
+pandas = { extras = ["performance"], version = "^2.2.2" }
 duckdb = "^0.10.2"
 pyyaml = "^6.0.1"
 deltalake = "^0.17.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ duckdb = "^0.10.2"
 pyyaml = "^6.0.1"
 deltalake = "^0.17.2"
 click = "^8.1.7"
+pytest = "^8.3.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/raipy_elt/utilities/archiving.py
+++ b/src/raipy_elt/utilities/archiving.py
@@ -1,8 +1,8 @@
-from pathlib import Path
 import logging
 import tarfile
-from typing import Optional, Sequence
 from enum import StrEnum
+from pathlib import Path
+from typing import Optional, Sequence
 
 from raipy_elt.utilities.misc import get_or_mkdir
 
@@ -63,7 +63,7 @@ def tarball_files(
 
     dest_dir = get_or_mkdir(dest_dir)
 
-    dest_pth = dest_dir / f"{dest_fname}.tar{"" if not cmprsn else cmprsn}"
+    dest_pth = dest_dir / f"{dest_fname}.tar{"" if not cmprsn else f'.{cmprsn}'}"
     md = f'w:{"" if not cmprsn else cmprsn}'
 
     debug(f"attempting to open file {dest_pth=} for writing in mode {md=}")
@@ -71,7 +71,10 @@ def tarball_files(
         info(f"tar file {dest_pth} opened")
         for file in src_files:
             try:
-                tar.add(file, recursive=retain_structure)
+                if retain_structure:
+                    tar.add(file)
+                else:
+                    tar.add(file, arcname=file.name)
                 debug(f"added {file=}.")
             except:
                 warning(f"an error occurred adding {file=}", exc_info=True)

--- a/src/raipy_elt/utilities/archiving.py
+++ b/src/raipy_elt/utilities/archiving.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import logging
+import tarfile
+from typing import Optional, Sequence
+from enum import StrEnum
+
+from raipy_elt.utilities.misc import get_or_mkdir
+
+
+class CompressAlg(StrEnum):
+    """
+    the compression algorithms natively supported by Python
+    """
+
+    GZIP = "gz"
+    BZIP2 = "bz2"
+    LZMA = "xz"
+
+
+GZIP, BZIP2, LZMA = CompressAlg
+
+
+def tarball_files(
+    src_files: Sequence[Path],
+    dest_dir: Path,
+    dest_fname: str,
+    cmprsn: Optional[CompressAlg] = GZIP,
+    retain_structure: bool = False,
+    logger: Optional[logging.Logger] = None,
+) -> Path:
+    """
+    receives a list (sequence) of files from which to create a tarball for cold storage and creates a
+    tarfile `{dest_dir}/{dest_file_name}.tar.{alg}`
+
+    :param src_files: list of files to include in the archive.
+    :param dest_dir: directory in which the tarball should be placed
+    :param dest_fname: file name for the tarball (excluding the parent directories), without suffix.
+    :param alg: compression algorithm to use (defaults to gzip)
+    :param retain_structure: retain the directory structure above the compressed files (false by default)
+    :logger: the logger used for logging messages in the function
+    """
+    logger = logger or logging.getLogger(__file__)
+    debug, info, warning = logger.debug, logger.info, logger.warning
+
+    debug(
+        f"tarball_files requested with parameters {src_files=}, {dest_dir=}, {dest_fname=}, {cmprsn=}, {retain_structure=}"
+    )
+
+    for file in src_files:
+        info(f"checking {file=} exists and is a file")
+        if not file.exists():
+            warning("received a file that does not exist.")
+            raise FileNotFoundError(
+                f"attempt to include {file=} in tarball, but file does not exist."
+            )
+
+        if not file.is_file():
+            warning("received a path to something other than a file.")
+            raise ValueError(
+                f"attempt to include {file=} in tarball, but path does not point to a file."
+            )
+        info(f"verified {file=} ok.")
+
+    dest_dir = get_or_mkdir(dest_dir)
+
+    dest_pth = dest_dir / f"{dest_fname}.tar{"" if not cmprsn else cmprsn}"
+    md = f'w:{"" if not cmprsn else cmprsn}'
+
+    debug(f"attempting to open file {dest_pth=} for writing in mode {md=}")
+    with tarfile.open(dest_pth, mode=md) as tar:
+        info(f"tar file {dest_pth} opened")
+        for file in src_files:
+            try:
+                tar.add(file, recursive=retain_structure)
+                debug(f"added {file=}.")
+            except:
+                warning(f"an error occurred adding {file=}", exc_info=True)
+                raise
+        info("all files added to tarball.")
+
+    info("returning path to new tarball")
+    return dest_pth

--- a/src/raipy_elt/utilities/archiving.py
+++ b/src/raipy_elt/utilities/archiving.py
@@ -87,12 +87,12 @@ def tarball_files(
     logger = logger or logging.getLogger(__file__)
     debug, info, warning = logger.debug, logger.info, logger.warning
 
-    debug(
+    info(
         f"tarball_files requested with parameters {src_files=}, {dest_dir=}, {dest_fname=}, {cmprsn=}, {retain_structure=}"
     )
 
     for file in src_files:
-        info(f"checking {file=} exists and is a file")
+        debug(f"checking {file=} exists and is a file")
         if not file.exists():
             warning("received a file that does not exist.")
             raise FileNotFoundError(
@@ -125,6 +125,10 @@ def tarball_files(
                 warning(f"an error occurred adding {file=}", exc_info=True)
                 raise
         info("all files added to tarball.")
+
+    for file in src_files:
+        info(f"removing {file=}")
+        file.unlink()  # remove files
 
     info("returning path to new tarball")
     return dest_pth

--- a/src/raipy_elt/utilities/dataframe.py
+++ b/src/raipy_elt/utilities/dataframe.py
@@ -85,3 +85,8 @@ def manual_parse(bad_file: Path, sep="|") -> pd.DataFrame:
         )
 
     return df
+
+
+def list_col_nonempty(df: pd.DataFrame, list_col: str) -> pd.Series:
+    """series of bool indicating if a column composed of lists is non empty"""
+    return df[list_col].apply(lambda el: False if not el else True)

--- a/test/test_raipy_elt/test_utilities/test_archiving.py
+++ b/test/test_raipy_elt/test_utilities/test_archiving.py
@@ -1,0 +1,119 @@
+from raipy_elt.utilities.archiving import tarball_files, CompressAlg
+import tarfile
+import pytest
+import logging
+from pathlib import Path
+
+
+@pytest.fixture
+def fxtr_files_dumb(tmp_path):
+    """
+    Fixture to create a temporary directory with some files to compress.
+    """
+    # Create a directory and some files to be added to the tarball
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    file_paths = []
+    for i in range(3):
+        file_path = test_dir / f"file{i}.txt"
+        file_path.write_text(f"This is test file {i}")
+        file_paths.append(file_path)
+
+    return file_paths, tmp_path
+
+
+@pytest.mark.parametrize(
+    "compression_alg, retain_structure, expected_extension",
+    [
+        (CompressAlg.GZIP, False, ".tar.gz"),
+        (CompressAlg.BZIP2, False, ".tar.bz2"),
+        (CompressAlg.LZMA, False, ".tar.xz"),
+        (CompressAlg.GZIP, True, ".tar.gz"),
+        (CompressAlg.BZIP2, True, ".tar.bz2"),
+        (CompressAlg.LZMA, True, ".tar.xz"),
+        (None, False, ".tar"),  # No compression algorithm case
+        (None, True, ".tar"),  # No compression with retain_structure=True
+    ],
+)
+def test_tarball_files(
+    fxtr_files_dumb, compression_alg, retain_structure, expected_extension
+):
+    """
+    Parameterized test for the tarball_files function, including cases without compression.
+    """
+    src_files, tmp_dir = fxtr_files_dumb
+    dest_fname = "test_archive"
+    dest_dir = tmp_dir / "output_dir"
+    dest_dir.mkdir()
+
+    logger = logging.getLogger("test_logger")
+
+    # Run the tarball_files function
+    tarball_path = tarball_files(
+        src_files=src_files,
+        dest_dir=dest_dir,
+        dest_fname=dest_fname,
+        cmprsn=compression_alg,
+        retain_structure=retain_structure,
+        logger=logger,
+    )
+
+    # Check if the tarball is created
+    assert tarball_path.exists()
+
+    tbfname = tarball_path.name
+    suf = tbfname[tbfname.find(".") :]
+    assert suf == expected_extension
+
+    # Check the contents of the tarball
+    mode = f"r:{compression_alg.value}" if compression_alg else "r"
+    with tarfile.open(tarball_path, mode=mode) as tar:
+        tar_names = tar.getnames()
+
+        if retain_structure:
+            expected_paths = (str(f)[1:] for f in src_files)
+        else:
+            expected_paths = [file.name for file in src_files]
+
+        for path in expected_paths:
+            assert path in tar_names
+
+
+@pytest.mark.parametrize(
+    "invalid_file_path, error_type",
+    [
+        (Path("/invalid/file/path.txt"), FileNotFoundError),  # Non-existent file path
+        (
+            lambda tmp_dir: tmp_dir / "some_directory",
+            ValueError,
+        ),  # Path exists, but is a directory
+    ],
+)
+def test_tarball_files_invalid_files(tmp_path, invalid_file_path, error_type):
+    """
+    Test cases for invalid file paths, expecting errors.
+    """
+    dest_fname = "test_archive"
+    dest_dir = tmp_path / "output_dir"
+    dest_dir.mkdir()
+
+    logger = logging.getLogger("test_logger")
+
+    # Create the invalid path or directory as needed
+    if callable(invalid_file_path):
+        invalid_file_path = invalid_file_path(tmp_path)
+        invalid_file_path.mkdir()  # This creates the directory
+
+    src_files = [invalid_file_path]
+
+    # Expect the appropriate exception based on the error case
+    with pytest.raises(error_type):
+        tarball_files(
+            src_files=src_files,
+            dest_dir=dest_dir,
+            dest_fname=dest_fname,
+            cmprsn=CompressAlg.GZIP,
+            retain_structure=False,
+            logger=logger,
+        )


### PR DESCRIPTION
- added archive_raws task to RawToBronze
- added parameters to RawToBronze:
   - archive_behaviour
   - archive_dir
   - archive_err_behaviour

see doc of archive_raws
```reST
archive raws cleans up the ingested raw data according to the behaviours provided. files that failed to ingest (were not written to the delta)
    will not be moved.

    :param behaviour: how files that ingested cleanly (no read errors or ingest errors) should be handled.

        - if None, no files will be moved.
        - if a tuple ("move", str), files will be moved to a directory under the archive_dir named by the second element of the tuple, concatenated
            with the current date and time.
        - if a tuple ("tarball", str), files will be moved to a tarball under the archive_dir named by the second element of the tuple concatenated
            with the current date and time, and suffixed with .tar.{suffix according to compression algorithm, either xz, gz, or bz2}

    :param err_behaviour: how files that ingested with errors (i.e were still written to delta, but had issues) should be handled.

        - if None, no files will be moved.
        - if "include", they will be included with the files without errors
        - if a tuple ("move", str), handled the same as above
        - if a tuple ("tarball", str), handled the same as above

    :param raw_dir: the path to the raw directory (to prepend to the file names from the ingestion_records)
    :param archive_dir: the path in which the archives should be placed
    :param alg: the compression algorithm
    :param ingestion_records: dataframe of ingestion records indicating errors and if the file was saved to delta, must have columns READ_ERRORS, INGEST_ERRORS, INGEST_SUCCESS
```
