### PR TITLE
v 0.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ version = "0.0.2"
 description = ""
 authors = ["apostoli <79337131+apostolos-geyer@users.noreply.github.com>"]
 readme = "README.md"
-packages = [
-    { include = "raipy_elt", from = "src" },
-]
+packages = [{ include = "raipy_elt", from = "src" }]
 
 [tool.poetry.scripts]
 raipy-elt = "raipy_elt.__main__:main"
@@ -15,11 +13,12 @@ raw2bronze = "raipy_elt.__main__:raw_to_bronze"
 [tool.poetry.dependencies]
 python = "^3.11"
 attrs = "^23.2.0"
-pandas = {extras = ["performance"], version = "^2.2.2"}
+pandas = { extras = ["performance"], version = "^2.2.2" }
 duckdb = "^0.10.2"
 pyyaml = "^6.0.1"
 deltalake = "^0.17.2"
 click = "^8.1.7"
+pytest = "^8.3.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "raipy-elt"
-version = "0.0.2"
+version = "0.0.3"
 description = ""
 authors = ["apostoli <79337131+apostolos-geyer@users.noreply.github.com>"]
 readme = "README.md"

--- a/src/raipy_elt/data_quality/checks.py
+++ b/src/raipy_elt/data_quality/checks.py
@@ -1,107 +1,19 @@
-from enum import Enum, auto
-from typing import NamedTuple, Sequence, overload
+from typing import overload
 
 import pandas as pd
 
-class ColumnDomainRelationship(Enum):
-    """
-    Enumeration used when checking that (a) column(s) of two dataframes
-    have values from the same set.
-    """
-
-    EQUAL = auto() 
-    """
-    Let `D_1` and `D_2` be `DataFrame`s with shared columns `C_0`, ... `C_n`.  
-
-    We say `D_1` and `D_2` have `ColumnDomainRelationship.EQUAL` on `C_i` ∈ [0, n] iff
-
-    `D_1[C_i].unique()` ⊆ `D_2[C_i].unique()` AND `D_2[C_i].unique()` ⊆ `D_1[C_i].unique()`
-
-    i.e the set of the values present in `D_1[C_i]` is the same as those in `D_2[C_i]`
-    """
-
-    LEFT_NOT_RIGHT = auto()
-    """
-    Let `D_1` and `D_2` be DataFrames with shared columns `C_0`, ... `C_n`.
-
-    We say `D_1` and `D_2` have `ColumnDomainRelationship.LEFT_NOT_RIGHT` on `C_i` ∈ [0, n] iff
-
-    `D_1[C_i].unique()` ⊆ `D_2[C_i].unique()` ^ `D_2[C_i].unique()` ⊈ `D_1[C_i].unique()`
-
-    i.e `D_2[C_i]` is covered by `D_1[C_i]` but `D_1[C_i]` is not covered by `D_2[C_i]`
-    """
+from raipy_elt.data_quality import errors
+from raipy_elt.data_quality.models import (
+    COL_MISSING,
+    DF_EMPTY,
+    ColumnDomainResult,
+)
 
 
-    RIGHT_NOT_LEFT = auto()
-    """
-    Let `D_1` and `D_2` be DataFrames with shared columns `C_0`, ... `C_n`.
-
-    We say `D_1` and `D_2` have `ColumnDomainRelationship.RIGHT_NOT_LEFT` on `C_i` ∈ [0, n] iff
-
-    `D_2[C_i].unique()` ⊆ `D_1[C_i].unique()` AND `D_1[C_i].unique()` ⊈ `D_2[C_i].unique()`
-
-    i.e `D_1[C_i]` is covered by `D_2[C_i]` but `D_2[C_i]` is not covered by `D_1[C_i]`
-    """
-
-
-    BOTH = auto()
-    """
-    Let `D_1` and `D_2` be DataFrames with shared columns `C_0`, ... `C_n`.
-
-    We say `D_1` and `D_2` have `ColumnDomainRelationship.BOTH` on `C_i` ∈ [0, n] iff
-
-    `D_1[C_i].unique()` ⊈ `D_2[C_i].unique()` AND `D_2[C_i].unique()` ⊈ `D_1[C_i].unique()`
-
-    i.e ∃ v ∈ `D_1[C_i]` s.t v ∉ `D_2[C_i]` and vice versa
-    """
-
-
-class ColumnDomainResult(NamedTuple):
-    """
-    NamedTuple for the result of the column domain check
-    """
-
-    relationship: ColumnDomainRelationship = ColumnDomainRelationship.EQUAL
-    """
-    The outcome of the column domain check
-    """
-
-    left_not_right: pd.Series | None = None
-    """
-    The values in the left DataFrame that are not in the right DataFrame
-    """
-
-
-    right_not_left: pd.Series | None = None
-    """
-    The values in the right DataFrame that are not in the left DataFrame
-    """
-
-
-def _check_column_value_sets(col: str, left: pd.DataFrame, right: pd.DataFrame) -> ColumnDomainResult:
-    """
-    Check that the column `col` of `left` and `right` have the same domain
-
-    :param col: the column to check
-    :param left: the left DataFrame
-    :param right: the right DataFrame
-    :returns: the result of the check
-    """
-
-    lnotr = left[~left[col].isin(right[col])][col]
-    rnotl = right[~right[col].isin(left[col])][col]
-    match (lnotr.empty, rnotl.empty):
-        case (True, True):
-            return ColumnDomainResult()
-        case (False, True):
-            return ColumnDomainResult(ColumnDomainRelationship.LEFT_NOT_RIGHT, lnotr)
-        case (True, False):
-            return ColumnDomainResult(ColumnDomainRelationship.RIGHT_NOT_LEFT, right_not_left=rnotl)
-        case (False, False):
-            return ColumnDomainResult(ColumnDomainRelationship.BOTH, lnotr, rnotl)
-    
 @overload
-def check_column_value_sets(col: str, left: pd.DataFrame, right: pd.DataFrame) -> ColumnDomainResult:
+def check_column_value_sets(
+    cols: str, left: pd.DataFrame, right: pd.DataFrame
+) -> ColumnDomainResult:
     """
     Check that the column `col` of `left` and `right` have the same set of values
 
@@ -112,8 +24,11 @@ def check_column_value_sets(col: str, left: pd.DataFrame, right: pd.DataFrame) -
     """
     ...
 
+
 @overload
-def check_column_value_sets(cols: Sequence[str], left: pd.DataFrame, right: pd.DataFrame) -> dict[str, ColumnDomainResult]:
+def check_column_value_sets(
+    cols: list[str] | tuple[str], left: pd.DataFrame, right: pd.DataFrame
+) -> dict[str, ColumnDomainResult]:
     """
     Check that the columns `cols` of `left` and `right` have the same set of values
 
@@ -124,7 +39,10 @@ def check_column_value_sets(cols: Sequence[str], left: pd.DataFrame, right: pd.D
     """
     ...
 
-def check_column_value_sets(cols: str | Sequence[str], left: pd.DataFrame, right: pd.DataFrame) -> ColumnDomainResult | dict[str, ColumnDomainResult]:
+
+def check_column_value_sets(
+    cols: str | list[str] | tuple[str], left: pd.DataFrame, right: pd.DataFrame
+) -> ColumnDomainResult | dict[str, ColumnDomainResult]:
     """
     Check that the column or columns `cols` of `left` and `right` have the same set of values
 
@@ -132,11 +50,88 @@ def check_column_value_sets(cols: str | Sequence[str], left: pd.DataFrame, right
     :param left: the left DataFrame
     :param right: the right DataFrame
     :returns: the result of the check
+    :raises: EmptyDataframe if either is empty, MissingColumn if either is missing any cols specified
     """
 
+    lempty, rempty = left.empty, right.empty
+    if lempty or rempty:
+        res: ColumnDomainResult
+        match (lempty, rempty):
+            case (True, True):
+                res = ColumnDomainResult.both(flag=DF_EMPTY)
+            case (True, False):
+                res = ColumnDomainResult.right_not_left(
+                    flag=DF_EMPTY
+                )  # right has values and left doesnt
+            case (False, True):
+                res = ColumnDomainResult.left_not_right(flag=DF_EMPTY)  # vice versa
+        raise errors.ColCheckOnEmptyDF(result=res)  # type: ignore (one of the above cases is true by lempty or rempty)
+
     if isinstance(cols, str):
+        missing_l, missing_r = cols not in left.columns, cols not in right.columns
+        if missing_l or missing_r:
+            res: ColumnDomainResult
+            match (missing_l, missing_r):
+                case (True, True):
+                    res = ColumnDomainResult.both(cols, cols, COL_MISSING)
+                case (True, False):
+                    res = ColumnDomainResult.right_not_left(cols, COL_MISSING)
+                case (False, True):
+                    res = ColumnDomainResult.left_not_right(cols, COL_MISSING)
+            raise errors.ColCheckOnMissingCol(result=res)  # type: ignore (one of the above cases is true by missing_l or missing_r)
         return _check_column_value_sets(cols, left, right)
-    elif isinstance(cols, Sequence):
+    elif isinstance(cols, tuple | list):
+        missing_from_l, missing_from_r = (
+            [col for col in cols if col not in df] for df in (left, right)
+        )
+        if missing_from_l or missing_from_r:
+            match (missing_from_l, missing_from_r):
+                case [[], mr]:
+                    res = ColumnDomainResult.left_not_right(mr, COL_MISSING)
+                case [ml, []]:
+                    res = ColumnDomainResult.right_not_left(ml, COL_MISSING)
+                case [ml, mr]:
+                    res = ColumnDomainResult.both(mr, ml, COL_MISSING)
+            raise errors.ColCheckOnMissingCol(result=res)
         return {col: _check_column_value_sets(col, left, right) for col in cols}
-    else:
-        raise TypeError("cols must be a str or a Sequence[str]")
+
+
+def _check_column_value_sets(
+    col: str, left: pd.DataFrame, right: pd.DataFrame
+) -> ColumnDomainResult:
+    """
+    Check that the column `col` of `left` and `right` have the same domain
+    should only be called if verified that col is in both dataframes and that both dataframes
+    arent empty
+
+    :param col: the column to check
+    :param left: the left DataFrame
+    :param right: the right DataFrame
+    :returns: the result of the check
+    """
+
+    lnotr, rnotl = (
+        _coldiff(col, _l, _r) for (_l, _r) in ((left, right), (right, left))
+    )
+    lcol: pd.Series | pd.DataFrame = lnotr[col]
+    rcol: pd.Series | pd.DataFrame = rnotl[col]
+
+    assert isinstance(lcol, pd.Series)
+    assert isinstance(rcol, pd.Series)
+
+    match (lcol.empty, rcol.empty):
+        case (True, True):
+            return ColumnDomainResult.equal()
+        case (False, True):
+            return ColumnDomainResult.left_not_right(values=lcol)
+        case (True, False):
+            return ColumnDomainResult.right_not_left(values=rcol)
+        case (False, False):
+            return ColumnDomainResult.both(lnotr=lcol, rnotl=rcol)
+
+
+def _coldiff(col: str, left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
+    """makes mypy / pyright shut up"""
+    diff = left[~left[col].isin(right[col])]
+    assert isinstance(diff, pd.DataFrame)
+    return diff

--- a/src/raipy_elt/data_quality/errors.py
+++ b/src/raipy_elt/data_quality/errors.py
@@ -1,8 +1,78 @@
+from typing import Self
+from raipy_elt.data_quality.models import (
+    ColumnDomainResult,
+    LEFT_NOT_RIGHT,
+    RIGHT_NOT_LEFT,
+    BOTH,
+    DF_EMPTY,
+    COL_MISSING,
+)
 
+
+class ColCheckOnEmptyDF(ValueError):
+    result: ColumnDomainResult
+
+    def __init__(self: Self, result: ColumnDomainResult) -> None:
+        if DF_EMPTY not in result.rel:
+            raise ValueError(
+                "invalid construction of ColCheckOnEmptyDF exception. DF_EMPTY flag should be in column domain result"
+            )
+        elif not any(
+            cdr in result.rel for cdr in (LEFT_NOT_RIGHT, RIGHT_NOT_LEFT, BOTH)
+        ):
+            raise ValueError(
+                "invalid construction of ColCheckOnEmptyDF exception. should have flag indicating which is empty (LEFT_NOT_RIGHT (right empty), RIGHT_NOT_LEFT (left empty), or BOTH)"
+            )
+
+        self.result = result
+        super().__init__(self._msg())
+
+    def _msg(self: Self) -> str:
+        tmpl = "Column value check is invalid. {why}"
+        why = ""
+        if LEFT_NOT_RIGHT in self.result.rel:
+            why = "Right dataframe is empty"
+        elif RIGHT_NOT_LEFT in self.result.rel:
+            why = "Left dataframe is empty"
+        elif BOTH in self.result.rel:
+            why = "Both dataframes are empty"
+        return tmpl.format(why=why)
+
+
+class ColCheckOnMissingCol(KeyError):
+    result: ColumnDomainResult
+
+    def __init__(self: Self, result: ColumnDomainResult) -> None:
+        if COL_MISSING not in result.rel:
+            raise ValueError(
+                "invalid construction of ColCheckOnMissingCol exception. COL_MISSING flag should be in column domain result"
+            )
+        elif not any(
+            cdr in result.rel for cdr in (LEFT_NOT_RIGHT, RIGHT_NOT_LEFT, BOTH)
+        ):
+            raise ValueError(
+                "invalid construction of ColCheckOnMissingCol exception. should have flag indicating which is missing (LEFT_NOT_RIGHT (missing in right), RIGHT_NOT_LEFT (missing in left), or BOTH)"
+            )
+
+        self.result = result
+        super().__init__(self._msg())
+
+    def _msg(self: Self) -> str:
+        tmpl = "Column value check is invalid. {why}"
+        why = ""
+        if LEFT_NOT_RIGHT in self.result.rel:
+            why = f"Right dataframe is missing column(s) {self.result.lnotr}"
+        if RIGHT_NOT_LEFT in self.result.rel:
+            why = f"Left dataframe is missing column(s) {self.result.rnotl}"
+        if BOTH in self.result.rel:
+            why = f"Right dataframe is missing column(s) {self.result.lnotr}, Left dataframe is missing column(s) {self.result.rnotl}"
+        return tmpl.format(why=why)
 
 
 class UncoveredAssessmentError(Exception):
-    def __init__(self, file_with: str, file_without: str, missing_ids: list[int], *args):
+    def __init__(
+        self, file_with: str, file_without: str, missing_ids: list[int], *args
+    ):
         super().__init__(args)
         self.file_with = file_with
         self.file_without = file_without

--- a/src/raipy_elt/data_quality/models.py
+++ b/src/raipy_elt/data_quality/models.py
@@ -1,0 +1,128 @@
+from enum import Flag, auto
+from typing import Optional, Self
+
+import pandas as pd
+from attrs import frozen
+
+
+class ColumnDomainRelationship(Flag):
+    """
+    Enumeration used when checking that (a) column(s) of two dataframes
+    have values from the same set.
+    """
+
+    EQUAL = auto()
+    """
+    Let `D_1` and `D_2` be `DataFrame`s with shared columns `C_0`, ... `C_n`.  
+
+    We say `D_1` and `D_2` have `ColumnDomainRelationship.EQUAL` on `C_i` ∈ [0, n] iff
+
+    `D_1[C_i].unique()` ⊆ `D_2[C_i].unique()` AND `D_2[C_i].unique()` ⊆ `D_1[C_i].unique()`
+
+    i.e the set of the values present in `D_1[C_i]` is the same as those in `D_2[C_i]`
+    """
+
+    LEFT_NOT_RIGHT = auto()
+    """
+    Let `D_1` and `D_2` be DataFrames with shared columns `C_0`, ... `C_n`.
+
+    We say `D_1` and `D_2` have `ColumnDomainRelationship.LEFT_NOT_RIGHT` on `C_i` ∈ [0, n] iff
+
+    `D_1[C_i].unique()` ⊆ `D_2[C_i].unique()` ^ `D_2[C_i].unique()` ⊈ `D_1[C_i].unique()`
+
+    i.e `D_2[C_i]` is covered by `D_1[C_i]` but `D_1[C_i]` is not covered by `D_2[C_i]`
+    """
+
+    RIGHT_NOT_LEFT = auto()
+    """
+    Let `D_1` and `D_2` be DataFrames with shared columns `C_0`, ... `C_n`.
+
+    We say `D_1` and `D_2` have `ColumnDomainRelationship.RIGHT_NOT_LEFT` on `C_i` ∈ [0, n] iff
+
+    `D_2[C_i].unique()` ⊆ `D_1[C_i].unique()` AND `D_1[C_i].unique()` ⊈ `D_2[C_i].unique()`
+
+    i.e `D_1[C_i]` is covered by `D_2[C_i]` but `D_2[C_i]` is not covered by `D_1[C_i]`
+    """
+
+    BOTH = auto()
+    """
+    Let `D_1` and `D_2` be DataFrames with shared columns `C_0`, ... `C_n`.
+
+    We say `D_1` and `D_2` have `ColumnDomainRelationship.BOTH` on `C_i` ∈ [0, n] iff
+
+    `D_1[C_i].unique()` ⊈ `D_2[C_i].unique()` AND `D_2[C_i].unique()` ⊈ `D_1[C_i].unique()`
+
+    i.e ∃ v ∈ `D_1[C_i]` s.t v ∉ `D_2[C_i]` and vice versa
+    """
+
+    DF_EMPTY = auto()
+    """
+    Flag to add when relationship is indicating left or right is empty
+    """
+
+    COL_MISSING = auto()
+    """
+    Flag to add when relationship is indicating left or right is missing column
+    """
+
+
+EQUAL, LEFT_NOT_RIGHT, RIGHT_NOT_LEFT, BOTH, DF_EMPTY, COL_MISSING = (
+    ColumnDomainRelationship
+)
+
+
+@frozen
+class ColumnDomainResult:
+    """
+    NamedTuple for the result of the column domain check
+    """
+
+    type ValueDiff = Optional[pd.Series | str | list[str]]
+    """
+    value difference representation. use a pd.Series when representing
+    difference between values in columns, a str or list[str] when representing column(s) not present,
+    and None when rel is EQUAL or representing emptiness of dataframes
+    """
+
+    rel: ColumnDomainRelationship
+    """
+    The outcome of the column domain check
+    """
+
+    lnotr: ValueDiff
+    """
+    The values in the left DataFrame that are not in the right DataFrame
+    """
+
+    rnotl: ValueDiff
+    """
+    The values in the right DataFrame that are not in the left DataFrame
+    """
+
+    @classmethod
+    def equal(cls) -> Self:
+        return cls(EQUAL, None, None)
+
+    @classmethod
+    def left_not_right(
+        cls, values: ValueDiff = None, flag: Optional[ColumnDomainRelationship] = None
+    ) -> Self:
+        rel = LEFT_NOT_RIGHT if flag is None else LEFT_NOT_RIGHT | flag
+        return cls(rel, values, None)
+
+    @classmethod
+    def right_not_left(
+        cls, values: ValueDiff = None, flag: Optional[ColumnDomainRelationship] = None
+    ) -> Self:
+        rel = RIGHT_NOT_LEFT if flag is None else RIGHT_NOT_LEFT | flag
+        return cls(rel, None, values)
+
+    @classmethod
+    def both(
+        cls,
+        lnotr: ValueDiff = None,
+        rnotl: ValueDiff = None,
+        flag: Optional[ColumnDomainRelationship] = None,
+    ) -> Self:
+        rel = BOTH if flag is None else BOTH | flag
+        return cls(rel, lnotr, rnotl)

--- a/src/raipy_elt/pipelines/records.py
+++ b/src/raipy_elt/pipelines/records.py
@@ -78,8 +78,8 @@ class ReadMetadata:
     n_residents: int
     n_facilities: int
     n_unique_assessments: int
-    errors: list[str] | None
-    success: bool
+    read_errors: list[str] | None
+    read_success: bool
 
     @classmethod
     def from_data(
@@ -91,8 +91,8 @@ class ReadMetadata:
                 n_residents=data["Resident ID"].nunique(),
                 n_unique_assessments=data.UNIQUE_ASSESSMENT_ID.nunique(),
                 n_facilities=data["Facility ID"].nunique(),
-                errors=errors or [],
-                success=True,
+                read_errors=errors or [],
+                read_success=True,
             )
             if data is not None
             else cls(
@@ -100,8 +100,8 @@ class ReadMetadata:
                 n_residents=-1,
                 n_unique_assessments=-1,
                 n_facilities=-1,
-                errors=errors or [],
-                success=False,
+                read_errors=errors or [],
+                read_success=False,
             )
         )
 
@@ -139,12 +139,16 @@ class ReadMetadata:
 class IngestionRecord:
     file_metadata: FileMetadata
     read_metadata: ReadMetadata
+    ingest_errors: list[str]
+    ingest_success: bool
     processed_timestamp: pd.Timestamp = field(factory=pd.Timestamp.now)
 
     def get_mapping(self) -> dict:
         return {
             **self.file_metadata.get_mapping(),
             **self.read_metadata.get_mapping(),
+            "INGEST_ERRORS": self.ingest_errors,
+            "INGEST_SUCCESS": self.ingest_success,
             "PROCESSED_TIMESTAMP": self.processed_timestamp,
         }
 

--- a/src/raipy_elt/utilities/archiving.py
+++ b/src/raipy_elt/utilities/archiving.py
@@ -1,0 +1,134 @@
+import logging
+import tarfile
+from enum import StrEnum
+from pathlib import Path
+from typing import Optional, Sequence
+
+from raipy_elt.utilities.misc import get_or_mkdir
+
+
+class CompressAlg(StrEnum):
+    """
+    the compression algorithms natively supported by Python
+    """
+
+    GZIP = "gz"
+    BZIP2 = "bz2"
+    LZMA = "xz"
+
+
+GZIP, BZIP2, LZMA = CompressAlg
+
+
+def move_files(
+    src_files: Sequence[Path], dest_dir: Path, logger: Optional[logging.Logger] = None
+) -> Path:
+    """
+    receives a list (sequence) of files and a dest directory to move them to
+
+    :param src_files: list of files to move
+    :param dest_dir: directory to move them to
+    :param logger: logger used for logging messages in the function
+
+    :raises ValueError: if path to something other than a file is given
+    :raises FileNotFoundError: if path doesnt exist
+
+    :returns: dest_dir unaltered
+    """
+    logger = logger or logging.getLogger(__file__)
+    debug, info, warning = logger.debug, logger.info, logger.warning
+
+    debug(f"move_files requested with parameters {src_files=}, {dest_dir=}")
+
+    for file in src_files:
+        info(f"checking {file=} exists and is a file")
+        if not file.exists():
+            warning("received a file that does not exist.")
+            raise FileNotFoundError(
+                f"attempt to move {file=}, but file does not exist."
+            )
+
+        if not file.is_file():
+            warning("received a path to something other than a file.")
+            raise ValueError(
+                f"attempt to move {file=}, but path does not point to a file."
+            )
+        info(f"verified {file=} ok.")
+
+    dest_dir = get_or_mkdir(dest_dir)
+    for file in src_files:
+        file.rename(dest_dir / file.name)
+
+
+def tarball_files(
+    src_files: Sequence[Path],
+    dest_dir: Path,
+    dest_fname: str,
+    cmprsn: Optional[CompressAlg] = GZIP,
+    retain_structure: bool = False,
+    logger: Optional[logging.Logger] = None,
+) -> Path:
+    """
+    receives a list (sequence) of files from which to create a tarball for cold storage and creates a
+    tarfile `{dest_dir}/{dest_file_name}.tar.{alg}`
+
+    :param src_files: list of files to include in the archive.
+    :param dest_dir: directory in which the tarball should be placed
+    :param dest_fname: file name for the tarball (excluding the parent directories), without suffix.
+    :param alg: compression algorithm to use (defaults to gzip)
+    :param retain_structure: retain the directory structure above the compressed files (false by default)
+    :param logger: the logger used for logging messages in the function
+
+    :raises ValueError: if path to something other than a file is given
+    :raises FileNotFoundError: if path doesnt exist
+
+    :returns: path to the archive
+    """
+    logger = logger or logging.getLogger(__file__)
+    debug, info, warning = logger.debug, logger.info, logger.warning
+
+    info(
+        f"tarball_files requested with parameters {src_files=}, {dest_dir=}, {dest_fname=}, {cmprsn=}, {retain_structure=}"
+    )
+
+    for file in src_files:
+        debug(f"checking {file=} exists and is a file")
+        if not file.exists():
+            warning("received a file that does not exist.")
+            raise FileNotFoundError(
+                f"attempt to include {file=} in tarball, but file does not exist."
+            )
+
+        if not file.is_file():
+            warning("received a path to something other than a file.")
+            raise ValueError(
+                f"attempt to include {file=} in tarball, but path does not point to a file."
+            )
+        info(f"verified {file=} ok.")
+
+    dest_dir = get_or_mkdir(dest_dir)
+
+    dest_pth = dest_dir / f"{dest_fname}.tar{"" if not cmprsn else f'.{cmprsn}'}"
+    md = f'w:{"" if not cmprsn else cmprsn}'
+
+    debug(f"attempting to open file {dest_pth=} for writing in mode {md=}")
+    with tarfile.open(dest_pth, mode=md) as tar:
+        info(f"tar file {dest_pth} opened")
+        for file in src_files:
+            try:
+                if retain_structure:
+                    tar.add(file)
+                else:
+                    tar.add(file, arcname=file.name)
+                debug(f"added {file=}.")
+            except:
+                warning(f"an error occurred adding {file=}", exc_info=True)
+                raise
+        info("all files added to tarball.")
+
+    for file in src_files:
+        info(f"removing {file=}")
+        file.unlink()  # remove files
+
+    info("returning path to new tarball")
+    return dest_pth

--- a/src/raipy_elt/utilities/dataframe.py
+++ b/src/raipy_elt/utilities/dataframe.py
@@ -85,3 +85,8 @@ def manual_parse(bad_file: Path, sep="|") -> pd.DataFrame:
         )
 
     return df
+
+
+def list_col_nonempty(df: pd.DataFrame, list_col: str) -> pd.Series:
+    """series of bool indicating if a column composed of lists is non empty"""
+    return df[list_col].apply(lambda el: False if not el else True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+test_dir = Path(__file__).parent
+proj_dir = test_dir.parent
+src_dir = proj_dir / "src"
+
+sys.path.insert(0, str(src_dir))
+
+print(f"inserted {src_dir} to path")

--- a/test/test_raipy_elt/test_data_quality/test_checks.py
+++ b/test/test_raipy_elt/test_data_quality/test_checks.py
@@ -1,0 +1,153 @@
+import pandas as pd
+import pytest
+from pytest import fixture, mark
+
+from raipy_elt.data_quality.checks import check_column_value_sets
+from raipy_elt.data_quality.errors import ColCheckOnEmptyDF, ColCheckOnMissingCol
+from raipy_elt.data_quality.models import (
+    BOTH,
+    COL_MISSING,
+    DF_EMPTY,
+    EQUAL,
+    LEFT_NOT_RIGHT,
+    RIGHT_NOT_LEFT,
+    ColumnDomainResult,
+)
+
+
+# Helper DataFrames
+@fixture
+def df_123_abc_short():
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+
+
+@fixture
+def df_1234_abc():
+    return pd.DataFrame({"col1": [1, 2, 3, 4], "col2": ["a", "a", "b", "c"]})
+
+
+@fixture
+def df_123_abc_long():
+    return pd.DataFrame(
+        {"col1": [1, 2, 3, 2, 2, 1, 3], "col2": ["a", "b", "c", "b", "b", "c", "a"]}
+    )
+
+
+@fixture
+def df_235_abd():
+    return pd.DataFrame({"col1": [2, 3, 5], "col2": ["a", "b", "d"]})
+
+
+@fixture
+def df_empty():
+    return pd.DataFrame()
+
+
+@mark.parametrize(
+    "l,r",
+    [
+        ("df_123_abc_short", "df_123_abc_short"),
+        ("df_123_abc_long", "df_123_abc_short"),
+        ("df_123_abc_short", "df_123_abc_long"),
+        ("df_123_abc_long", "df_123_abc_long"),
+    ],
+)
+def test_equal_columns(l, r, request):  # noqa: E741
+    ldf = request.getfixturevalue(l)
+    rdf = request.getfixturevalue(r)
+
+    result = check_column_value_sets("col1", ldf, rdf)
+    assert isinstance(result, ColumnDomainResult)
+    assert result.rel == EQUAL
+    assert result.lnotr is None
+    assert result.rnotl is None
+
+    multi_results = check_column_value_sets(["col1", "col2"], ldf, rdf)
+    col1res = multi_results["col1"]
+    col2res = multi_results["col2"]
+    assert col1res == col2res == result
+    # should be the same since we know column values are
+    # from the same set, therefore we should get identical result
+    # objects
+
+
+### Tests for LEFT_NOT_RIGHT Relationship
+@mark.parametrize(
+    "l,r", [("df_1234_abc", "df_123_abc_short"), ("df_1234_abc", "df_123_abc_long")]
+)
+def test_left_not_right(l, r, request):  # noqa: E741
+    ldf = request.getfixturevalue(l)
+    rdf = request.getfixturevalue(r)
+    result = check_column_value_sets("col1", ldf, rdf)
+    assert isinstance(result, ColumnDomainResult)
+    assert result.rel == LEFT_NOT_RIGHT
+    assert (
+        result.lnotr.tolist() == pd.Series([4]).tolist()  # type: ignore
+    )  # Value 1 is in left but not in right
+
+
+### Tests for RIGHT_NOT_LEFT Relationship
+@mark.parametrize(
+    "l,r", [("df_123_abc_short", "df_1234_abc"), ("df_123_abc_long", "df_1234_abc")]
+)
+def test_right_not_left(l, r, request):  # noqa: E741
+    ldf = request.getfixturevalue(l)
+    rdf = request.getfixturevalue(r)
+    result = check_column_value_sets("col1", ldf, rdf)
+    assert isinstance(result, ColumnDomainResult)
+    assert result.rel == RIGHT_NOT_LEFT
+    assert (
+        result.rnotl.tolist() == pd.Series([4]).tolist()  # type: ignore
+    )  # Value 4 is in right but not in left
+
+
+### Tests for BOTH Relationship
+def test_both_columns(df_1234_abc, df_235_abd):
+    ldf, rdf = df_1234_abc, df_235_abd
+    result = check_column_value_sets(["col1", "col2"], ldf, rdf)
+    c1res = result["col1"]
+    c2res = result["col2"]
+
+    assert c1res.rel == BOTH
+    assert c2res.rel == BOTH
+    assert c1res.lnotr.tolist() == pd.Series([1, 4]).tolist()  # type: ignore
+    assert c1res.rnotl.tolist() == pd.Series([5]).tolist()  # type: ignore
+    assert c2res.lnotr.tolist() == pd.Series(["c"]).tolist()  # type: ignore
+    assert c2res.rnotl.tolist() == pd.Series(["d"]).tolist()  # type: ignore
+
+
+### Tests for Empty DataFrames
+def test_both_empty(df_empty):
+    with pytest.raises(ColCheckOnEmptyDF) as exc:
+        check_column_value_sets("col1", df_empty, df_empty)
+    assert exc.value.result.rel == DF_EMPTY | BOTH
+
+
+def test_left_empty(df_empty, df_235_abd):
+    with pytest.raises(ColCheckOnEmptyDF) as exc:
+        check_column_value_sets("col1", df_empty, df_235_abd)
+    assert exc.value.result.rel == DF_EMPTY | RIGHT_NOT_LEFT
+
+
+def test_right_empty(df_235_abd, df_empty):
+    with pytest.raises(ColCheckOnEmptyDF) as exc:
+        check_column_value_sets("col1", df_235_abd, df_empty)
+    assert exc.value.result.rel == DF_EMPTY | LEFT_NOT_RIGHT
+
+
+### Tests for Missing Columns
+def test_missing_columns(df_235_abd):
+    l, r = df_235_abd.copy(), df_235_abd.copy()  # noqa: E741
+
+    with pytest.raises(ColCheckOnMissingCol) as exc:
+        check_column_value_sets("col3", l, r)
+    assert exc.value.result.rel == COL_MISSING | BOTH
+
+    l["col3"] = l["col2"]
+    with pytest.raises(ColCheckOnMissingCol) as exc:
+        check_column_value_sets("col3", l, r)
+    assert exc.value.result.rel == COL_MISSING | LEFT_NOT_RIGHT
+
+    with pytest.raises(ColCheckOnMissingCol) as exc:
+        check_column_value_sets("col3", r, l)
+    assert exc.value.result.rel == COL_MISSING | RIGHT_NOT_LEFT

--- a/test/test_raipy_elt/test_data_quality/test_errors.py
+++ b/test/test_raipy_elt/test_data_quality/test_errors.py
@@ -1,0 +1,109 @@
+import pytest
+from raipy_elt.data_quality.errors import ColCheckOnEmptyDF, ColCheckOnMissingCol
+from raipy_elt.data_quality.models import (
+    ColumnDomainResult,
+    DF_EMPTY,
+    COL_MISSING,
+    LEFT_NOT_RIGHT,
+    RIGHT_NOT_LEFT,
+    BOTH,
+    EQUAL,
+)
+
+
+def test_empty_dataframe_error_message():
+    result = ColumnDomainResult(DF_EMPTY | RIGHT_NOT_LEFT, None, None)
+    with pytest.raises(ColCheckOnEmptyDF) as exc:
+        raise ColCheckOnEmptyDF(result)
+    assert "Left dataframe is empty" in str(exc.value)
+
+
+def test_missing_column_error_message():
+    result = ColumnDomainResult(COL_MISSING | LEFT_NOT_RIGHT, ["missing_col"], None)
+    with pytest.raises(ColCheckOnMissingCol) as exc:
+        raise ColCheckOnMissingCol(result)
+    assert "Right dataframe is missing column(s) ['missing_col']" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "rel, expected_error_message",
+    [
+        (EQUAL, "DF_EMPTY flag should be in column domain result"),
+        (LEFT_NOT_RIGHT, "DF_EMPTY flag should be in column domain result"),
+        (RIGHT_NOT_LEFT, "DF_EMPTY flag should be in column domain result"),
+        (BOTH, "DF_EMPTY flag should be in column domain result"),
+    ],
+)
+def test_invalid_empty_df_exception_construction(rel, expected_error_message):
+    """
+    Test that constructing `ColCheckOnEmptyDF` without the `DF_EMPTY` flag raises ValueError.
+    """
+    invalid_result = ColumnDomainResult(rel, None, None)
+
+    with pytest.raises(ValueError) as exc:
+        raise ColCheckOnEmptyDF(invalid_result)
+
+    assert expected_error_message in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "rel, expected_error_message",
+    [
+        (EQUAL, "COL_MISSING flag should be in column domain result"),
+        (LEFT_NOT_RIGHT, "COL_MISSING flag should be in column domain result"),
+        (RIGHT_NOT_LEFT, "COL_MISSING flag should be in column domain result"),
+        (BOTH, "COL_MISSING flag should be in column domain result"),
+    ],
+)
+def test_invalid_missing_col_exception_construction(rel, expected_error_message):
+    """
+    Test that constructing `ColCheckOnMissingCol` without the `COL_MISSING` flag raises ValueError.
+    """
+    invalid_result = ColumnDomainResult(rel, None, None)
+
+    with pytest.raises(ValueError) as exc:
+        raise ColCheckOnMissingCol(invalid_result)
+
+    assert expected_error_message in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "rel, expected_error_message",
+    [
+        (DF_EMPTY, "should have flag indicating which is empty"),
+        (DF_EMPTY | COL_MISSING, "should have flag indicating which is empty"),
+    ],
+)
+def test_invalid_empty_df_exception_construction_without_side_flag(
+    rel, expected_error_message
+):
+    """
+    Test that constructing `ColCheckOnEmptyDF` without LEFT_NOT_RIGHT or RIGHT_NOT_LEFT raises ValueError.
+    """
+    invalid_result = ColumnDomainResult(rel, None, None)
+
+    with pytest.raises(ValueError) as exc:
+        raise ColCheckOnEmptyDF(invalid_result)
+
+    assert expected_error_message in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "rel, expected_error_message",
+    [
+        (COL_MISSING, "should have flag indicating which is missing"),
+        (COL_MISSING | DF_EMPTY, "should have flag indicating which is missing"),
+    ],
+)
+def test_invalid_missing_col_exception_construction_without_side_flag(
+    rel, expected_error_message
+):
+    """
+    Test that constructing `ColCheckOnMissingCol` without LEFT_NOT_RIGHT or RIGHT_NOT_LEFT raises ValueError.
+    """
+    invalid_result = ColumnDomainResult(rel, None, None)
+
+    with pytest.raises(ValueError) as exc:
+        raise ColCheckOnMissingCol(invalid_result)
+
+    assert expected_error_message in str(exc.value)

--- a/test/test_raipy_elt/test_data_quality/test_models.py
+++ b/test/test_raipy_elt/test_data_quality/test_models.py
@@ -1,0 +1,35 @@
+from raipy_elt.data_quality.models import (
+    ColumnDomainResult,
+    EQUAL,
+    LEFT_NOT_RIGHT,
+    RIGHT_NOT_LEFT,
+    BOTH,
+)
+
+
+def test_column_domain_result_equal():
+    result = ColumnDomainResult.equal()
+    assert result.rel == EQUAL
+    assert result.lnotr is None
+    assert result.rnotl is None
+
+
+def test_column_domain_result_left_not_right():
+    result = ColumnDomainResult.left_not_right(["missing"])
+    assert result.rel == LEFT_NOT_RIGHT
+    assert result.lnotr == ["missing"]
+    assert result.rnotl is None
+
+
+def test_column_domain_result_right_not_left():
+    result = ColumnDomainResult.right_not_left(["extra"])
+    assert result.rel == RIGHT_NOT_LEFT
+    assert result.lnotr is None
+    assert result.rnotl == ["extra"]
+
+
+def test_column_domain_result_both():
+    result = ColumnDomainResult.both(["left_missing"], ["right_missing"])
+    assert result.rel == BOTH
+    assert result.lnotr == ["left_missing"]
+    assert result.rnotl == ["right_missing"]

--- a/test/test_raipy_elt/test_utilities/test_archiving.py
+++ b/test/test_raipy_elt/test_utilities/test_archiving.py
@@ -1,0 +1,119 @@
+from raipy_elt.utilities.archiving import tarball_files, CompressAlg
+import tarfile
+import pytest
+import logging
+from pathlib import Path
+
+
+@pytest.fixture
+def fxtr_files_dumb(tmp_path):
+    """
+    Fixture to create a temporary directory with some files to compress.
+    """
+    # Create a directory and some files to be added to the tarball
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    file_paths = []
+    for i in range(3):
+        file_path = test_dir / f"file{i}.txt"
+        file_path.write_text(f"This is test file {i}")
+        file_paths.append(file_path)
+
+    return file_paths, tmp_path
+
+
+@pytest.mark.parametrize(
+    "compression_alg, retain_structure, expected_extension",
+    [
+        (CompressAlg.GZIP, False, ".tar.gz"),
+        (CompressAlg.BZIP2, False, ".tar.bz2"),
+        (CompressAlg.LZMA, False, ".tar.xz"),
+        (CompressAlg.GZIP, True, ".tar.gz"),
+        (CompressAlg.BZIP2, True, ".tar.bz2"),
+        (CompressAlg.LZMA, True, ".tar.xz"),
+        (None, False, ".tar"),  # No compression algorithm case
+        (None, True, ".tar"),  # No compression with retain_structure=True
+    ],
+)
+def test_tarball_files(
+    fxtr_files_dumb, compression_alg, retain_structure, expected_extension
+):
+    """
+    Parameterized test for the tarball_files function, including cases without compression.
+    """
+    src_files, tmp_dir = fxtr_files_dumb
+    dest_fname = "test_archive"
+    dest_dir = tmp_dir / "output_dir"
+    dest_dir.mkdir()
+
+    logger = logging.getLogger("test_logger")
+
+    # Run the tarball_files function
+    tarball_path = tarball_files(
+        src_files=src_files,
+        dest_dir=dest_dir,
+        dest_fname=dest_fname,
+        cmprsn=compression_alg,
+        retain_structure=retain_structure,
+        logger=logger,
+    )
+
+    # Check if the tarball is created
+    assert tarball_path.exists()
+
+    tbfname = tarball_path.name
+    suf = tbfname[tbfname.find(".") :]
+    assert suf == expected_extension
+
+    # Check the contents of the tarball
+    mode = f"r:{compression_alg.value}" if compression_alg else "r"
+    with tarfile.open(tarball_path, mode=mode) as tar:
+        tar_names = tar.getnames()
+
+        if retain_structure:
+            expected_paths = (str(f)[1:] for f in src_files)
+        else:
+            expected_paths = [file.name for file in src_files]
+
+        for path in expected_paths:
+            assert path in tar_names
+
+
+@pytest.mark.parametrize(
+    "invalid_file_path, error_type",
+    [
+        (Path("/invalid/file/path.txt"), FileNotFoundError),  # Non-existent file path
+        (
+            lambda tmp_dir: tmp_dir / "some_directory",
+            ValueError,
+        ),  # Path exists, but is a directory
+    ],
+)
+def test_tarball_files_invalid_files(tmp_path, invalid_file_path, error_type):
+    """
+    Test cases for invalid file paths, expecting errors.
+    """
+    dest_fname = "test_archive"
+    dest_dir = tmp_path / "output_dir"
+    dest_dir.mkdir()
+
+    logger = logging.getLogger("test_logger")
+
+    # Create the invalid path or directory as needed
+    if callable(invalid_file_path):
+        invalid_file_path = invalid_file_path(tmp_path)
+        invalid_file_path.mkdir()  # This creates the directory
+
+    src_files = [invalid_file_path]
+
+    # Expect the appropriate exception based on the error case
+    with pytest.raises(error_type):
+        tarball_files(
+            src_files=src_files,
+            dest_dir=dest_dir,
+            dest_fname=dest_fname,
+            cmprsn=CompressAlg.GZIP,
+            retain_structure=False,
+            logger=logger,
+        )


### PR DESCRIPTION
new behaviours:
ingestion log table has additional columns ingest errors and ingest success to differentiate between being read successfully and written successfully


archive_raws stage:
from https://github.com/apostolos-geyer/raipy-elt/pull/9#issue-2520254504
> * added archive_raws task to RawToBronze
> * added parameters to RawToBronze:
>   
>   * archive_behaviour
>   * archive_dir
>   * archive_err_behaviour
> 
> see doc of archive_raws
> 
> ```
> archive raws cleans up the ingested raw data according to the behaviours provided. files that failed to ingest (were not written to the delta)
>     will not be moved.
> 
>     :param behaviour: how files that ingested cleanly (no read errors or ingest errors) should be handled.
> 
>         - if None, no files will be moved.
>         - if a tuple ("move", str), files will be moved to a directory under the archive_dir named by the second element of the tuple, concatenated
>             with the current date and time.
>         - if a tuple ("tarball", str), files will be moved to a tarball under the archive_dir named by the second element of the tuple concatenated
>             with the current date and time, and suffixed with .tar.{suffix according to compression algorithm, either xz, gz, or bz2}
> 
>     :param err_behaviour: how files that ingested with errors (i.e were still written to delta, but had issues) should be handled.
> 
>         - if None, no files will be moved.
>         - if "include", they will be included with the files without errors
>         - if a tuple ("move", str), handled the same as above
>         - if a tuple ("tarball", str), handled the same as above
> 
>     :param raw_dir: the path to the raw directory (to prepend to the file names from the ingestion_records)
>     :param archive_dir: the path in which the archives should be placed
>     :param alg: the compression algorithm
>     :param ingestion_records: dataframe of ingestion records indicating errors and if the file was saved to delta, must have columns READ_ERRORS, INGEST_ERRORS, INGEST_SUCCESS
> ```


